### PR TITLE
Update using to run on node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,5 +74,5 @@ inputs:
     required: false
     default: 750
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
users have been getting warnings about node12's deprecation for a couple of months now. This change seeks to update the code to run on node16.