### PR TITLE
Update to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,5 +74,5 @@ inputs:
     required: false
     default: 750
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
We were receiving deprecation notices b/c this was running on node 16. 
Update the action to node 20.

Closes: https://github.com/iFaxity/wait-on-action/issues/12